### PR TITLE
Accept `context` override in `/sessions/:id/memory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ curl --location 'localhost:8080/sessions/${SESSION_ID}/memory' \
     "messages": [{ "role": "Human", "content": "ping" }, { "role": "AI", "content": "pong" }]
 }'
 ```
+
+Optionally, `context` can be send in if it needs to get loaded from another datastore.
+
 - DELETE `/sessions/:id/memory` - deletes the session's message list.
 
 A max `window_size` is set for the LLM to keep track of the conversation. Once that max is hit, Motörhead will process (`window_size  / 2` messages) and summarize them. Subsequent summaries, as the messages grow, are incremental.

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,8 +17,9 @@ pub struct MemoryMessage {
 }
 
 #[derive(Deserialize)]
-pub struct MemoryMessages {
+pub struct MemoryMessagesAndContext {
     pub messages: Vec<MemoryMessage>,
+    pub context: Option<String>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
- For an initial load now `context` can be optionally passed in. This can simplify workflows where conversations are loaded from other datastores.
- The POST `/sessions/:id/memory` endpoint now takes:

```json
{
    "messages": [{ "role": "AI", "content": "france is cool" }, { "role": "human", "content": "is france is cool?" }],
    "context": "the conversation started talking about Kafka's The Metamorphosis"
}
```

closes https://github.com/getmetal/motorhead/issues/22