### PR TITLE
Change trigger to relase created for docker image

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -10,8 +10,8 @@
 name: Publish a Docker image
 
 on:
-  push:
-    branches: ['release']
+  release:
+    types: [created]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Fixes workflow so it creates a docker image whenever a release is created.