### PR TITLE
handle build warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,20 @@ async fn main() -> io::Result<()> {
     .bind(("0.0.0.0", port))?
     .run();
 
-    tokio::join!(server, on_start_logger(port));
+    let server_future = server;
+    let logger_future = on_start_logger(port);
+
+    let (server_result, logger_result) = tokio::join!(server_future, logger_future);
+
+    // Handle the Result from server
+    if let Err(e) = server_result {
+        eprintln!("Server error: {}", e);
+    }
+
+    // Handle the Result from logger
+    if let Err(e) = logger_result {
+        eprintln!("Logger error: {}", e);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Handle the following warning:

```
=> [build 11/11] RUN cargo build --release                                                                                                                                 4.0s
 => => #     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 => => #     |
 => => #     = note: this `Result` may be an `Err` variant, which should be handled
 => => #     = note: `#[warn(unused_must_use)]` on by default
 => => #     = note: this warning originates in the macro `$crate::join` which comes from the expansion of the macro `tokio::join` (in Nightly builds, run with -Z macro-backtra
 => => # ce for more info)
 ```