### PR TITLE
Move `apt-get` to top of Dockerfile for better caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM rust:1.68-bullseye as build
 
+# had to add this for open-ssl
+RUN apt-get update -y && \
+  apt-get install -y pkg-config make g++ libssl-dev ca-certificates && \
+  rustup target add x86_64-unknown-linux-gnu
+
 RUN USER=root cargo new --bin motorhead
 WORKDIR /motorhead
 
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
-
-# had to add this for open-ssl
-RUN apt-get update -y && \
-  apt-get install -y pkg-config make g++ libssl-dev ca-certificates && \
-  rustup target add x86_64-unknown-linux-gnu
 
 # cache dependencies
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true


### PR DESCRIPTION
Small adjustment to move the `apt-get` above the `COPY ./Cargo.lock ./Cargo.lock`, so that it can be cached more often.